### PR TITLE
バグ修正と地図の指定の仕方の変更

### DIFF
--- a/orne_waypoints_editor/launch/edit_waypoints_joy.launch
+++ b/orne_waypoints_editor/launch/edit_waypoints_joy.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <launch>
-  <arg name="map_file" default="$(find orne_navigation_executor)/maps/mymap.yaml"/>
+  <arg name="map_file" default="$(find orne_navigation_executor)/maps/mymap"/>
   <arg name="waypoints_file" default="$(find orne_navigation_executor)/waypoints_cfg/waypoints.yaml"/>
   <arg name="save_joy_button" default="0"/>
   <arg name="joy_config" default="elecom_joy"/>
@@ -12,7 +12,6 @@
     <arg name="joy_dev" value="$(arg joy_dev)"/>
   </include>
 
-  <node name="map_server" pkg="map_server" type="map_server" args="$(arg map_file)"/>
 
   <node pkg="orne_waypoints_editor" name="orne_waypoints_editor" type="orne_waypoints_editor" output="screen">
     <param name="filename" value="$(arg waypoints_file)"/>

--- a/orne_waypoints_editor/launch/edit_waypoints_joy_beta.launch
+++ b/orne_waypoints_editor/launch/edit_waypoints_joy_beta.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <launch>
-  <arg name="map_file" default="$(find orne_navigation_executor)/maps/mymap.yaml"/>
+  <arg name="map_file" default="$(find orne_navigation_executor)/maps/mymap"/>
   <arg name="waypoints_file" default="$(find orne_navigation_executor)/waypoints_cfg/waypoints_beta.yaml"/>
   <arg name="save_joy_button" default="0"/>
   <arg name="joy_config" default="elecom_joy"/>
@@ -12,8 +12,6 @@
     <arg name="joy_dev" value="$(arg joy_dev)"/>
   </include>
 
-  <node name="map_server" pkg="map_server" type="map_server" args="$(arg map_file)"/>
-
   <node pkg="orne_waypoints_editor" name="orne_waypoints_editor" type="orne_waypoints_editor" output="screen">
     <param name="filename" value="$(arg waypoints_file)"/>
     <param name="world_frame" value="map"/>
@@ -23,7 +21,9 @@
     <remap from="waypoints_joy" to="joy"/>
   </node>
 
-  <include file="$(find orne_navigation_executor)/launch/localization_beta.launch"/>
+  <include file="$(find orne_navigation_executor)/launch/localization.launch">
+	  <arg name="robot_name" value="beta"/>
+  </include>
 
   <node pkg="rviz" type="rviz" name="rviz" args="-d $(find orne_waypoints_editor)/rviz_cfg/orne_waypoints_editor.rviz"/>
 </launch>

--- a/orne_waypoints_editor/launch/edit_waypoints_viz.launch
+++ b/orne_waypoints_editor/launch/edit_waypoints_viz.launch
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 
 <launch>
-  <arg name="map_file" default="$(find orne_navigation_executor)/maps/mymap.yaml"/>
+  <arg name="map_file" default="$(find orne_navigation_executor)/maps/mymap"/>
   <arg name="waypoints_file" default="$(find orne_navigation_executor)/waypoints_cfg/waypoints.yaml"/>
 
-  <node name="map_server" pkg="map_server" type="map_server" args="$(arg map_file)"/>
+  <node name="map_server" pkg="map_server" type="map_server" args="$(arg map_file).yaml"/>
 
   <node pkg="orne_waypoints_editor" name="orne_waypoints_editor" type="orne_waypoints_editor" output="screen">
     <param name="filename" value="$(arg waypoints_file)"/>


### PR DESCRIPTION
ジョイスティックでwaypoitnsを編集する際にmap_serverが二度読み込まれるバグの修正、
及び地図名の指定の仕方をplay_waypoints_navと同様.yamlなしで読み込めるようにした